### PR TITLE
Commented out deprecated boost function

### DIFF
--- a/core/ambf_framework/afPath.h
+++ b/core/ambf_framework/afPath.h
@@ -81,9 +81,9 @@ public:
         return m_path.is_absolute();
     }
 
-    bool is_complete(){
-        return m_path.is_complete();
-    }
+    // bool is_complete(){
+    //     return m_path.is_complete();
+    // }
 
     // If this path is relative, it will be appended to the provided parent path
     bool resolvePath(const afPath& a_parentPath){


### PR DESCRIPTION
afPath is a wrapper for a boost::filesystem::path. The is_complete() function has been removed from newer versions of boost, which creates issues when compiling an ambf plugin that uses a newer version of boost. From what I can tell, there are no calls to afPath.is_complete(), so it should be safe to comment out the function.